### PR TITLE
1. JSONシステムの堅牢化・例外ログ出力

### DIFF
--- a/project/engine/jsonEditor/JsonEditableBase.cpp
+++ b/project/engine/jsonEditor/JsonEditableBase.cpp
@@ -1,6 +1,7 @@
 #include "JsonEditableBase.h"
 
 #include <fstream>
+#include <filesystem>
 
 // JSONインデント幅
 constexpr int kJsonIndent = 4;
@@ -26,12 +27,20 @@ bool JsonEditableBase::LoadJson(const std::string& path)
 	std::ifstream ifs(fullPath);
 	if (!ifs)
 	{
-		Logger::Log("Failed to open JSON file: " + path);
+		Logger::Log("[JSON Error] Failed to open JSON file: " + fullPath + "\n");
 		return false;
 	}
 
 	nlohmann::json json;
-	ifs >> json;
+	try
+	{
+		ifs >> json;
+	}
+	catch (const std::exception& e)
+	{
+		Logger::Log("[JSON Error] Parsing exception in file '" + fullPath + "': " + std::string(e.what()) + "\n");
+		return false;
+	}
 
 #ifdef _DEBUG
 	// デバッグ: 読み込んだファイルパスとobjects配列サイズ
@@ -56,63 +65,70 @@ bool JsonEditableBase::LoadJson(const std::string& path)
     // 登録済みsetterのみ値をセット
     for (const auto& [key, setter] : setters_)
     {
-        const nlohmann::json* current = &json;
-        size_t pos = 0, next;
-        std::string keyPath = key;
-        bool found = true;
+		try
+		{
+			const nlohmann::json* current = &json;
+			size_t pos = 0, next;
+			std::string keyPath = key;
+			bool found = true;
         
-        // ドット区切りのパスを辿る
-        while ((next = keyPath.find('.', pos)) != std::string::npos)
-        {
-            std::string token = keyPath.substr(pos, next - pos);
-            // 配列インデックス対応
-            size_t arrPos = token.find('[');
-            if (arrPos != std::string::npos)
-            {
-                std::string arrName = token.substr(0, arrPos);
-                size_t arrEnd = token.find(']', arrPos);
-                int idx = std::stoi(token.substr(arrPos + 1, arrEnd - arrPos - 1));
-                if (current->contains(arrName) && (*current)[arrName].is_array() && idx < (*current)[arrName].size())
-                {
-                    current = &(*current)[arrName][idx];
-                }
-                else
-                {
-                    found = false;
-                    break;
-                }
-            }
-            else
-            {
-                if (current->contains(token))
-                    current = &(*current)[token];
-                else
-                {
-                    found = false;
-                    break;
-                }
-            }
-            pos = next + 1;
-        }
+			// ドット区切りのパスを辿る
+			while ((next = keyPath.find('.', pos)) != std::string::npos)
+			{
+				std::string token = keyPath.substr(pos, next - pos);
+				// 配列インデックス対応
+				size_t arrPos = token.find('[');
+				if (arrPos != std::string::npos)
+				{
+					std::string arrName = token.substr(0, arrPos);
+					size_t arrEnd = token.find(']', arrPos);
+					int idx = std::stoi(token.substr(arrPos + 1, arrEnd - arrPos - 1));
+					if (current->contains(arrName) && (*current)[arrName].is_array() && idx < (*current)[arrName].size())
+					{
+						current = &(*current)[arrName][idx];
+					}
+					else
+					{
+						found = false;
+						break;
+					}
+				}
+				else
+				{
+					if (current->contains(token))
+						current = &(*current)[token];
+					else
+					{
+						found = false;
+						break;
+					}
+				}
+				pos = next + 1;
+			}
         
-        // 最後のトークンを処理
-        std::string lastToken = keyPath.substr(pos);
-        // 配列インデックス対応
-        size_t arrPos = lastToken.find('[');
-        if (arrPos != std::string::npos)
-        {
-            std::string arrName = lastToken.substr(0, arrPos);
-            size_t arrEnd = lastToken.find(']', arrPos);
-            int idx = std::stoi(lastToken.substr(arrPos + 1, arrEnd - arrPos - 1));
-            if (current->contains(arrName) && (*current)[arrName].is_array() && idx < (*current)[arrName].size())
-            {
-                SetValue(key, (*current)[arrName][idx]);
-            }
-        }
-        else if (found && current->contains(lastToken))
-        {
-            SetValue(key, (*current)[lastToken]);
-        }
+			// 最後のトークンを処理
+			std::string lastToken = keyPath.substr(pos);
+			// 配列インデックス対応
+			size_t arrPos = lastToken.find('[');
+			if (arrPos != std::string::npos)
+			{
+				std::string arrName = lastToken.substr(0, arrPos);
+				size_t arrEnd = lastToken.find(']', arrPos);
+				int idx = std::stoi(lastToken.substr(arrPos + 1, arrEnd - arrPos - 1));
+				if (current->contains(arrName) && (*current)[arrName].is_array() && idx < (*current)[arrName].size())
+				{
+					SetValue(key, (*current)[arrName][idx]);
+				}
+			}
+			else if (found && current->contains(lastToken))
+			{
+				SetValue(key, (*current)[lastToken]);
+			}
+		}
+		catch (const std::exception& e)
+		{
+			Logger::Log("[JSON Warning] Value assignment failed for key '" + key + "': " + std::string(e.what()) + "\n");
+		}
     }
 
 	return true;
@@ -126,35 +142,179 @@ bool JsonEditableBase::SaveJson(const std::string& path) const
 	// すべての登録済みプロパティをJSONに変換
 	for (auto& [key, getter] : getters_)
 	{
-		json[key] = getter();
+		try
+		{
+			json[key] = getter();
+		}
+		catch (const std::exception& e)
+		{
+			Logger::Log("[JSON Error] Failed to serialize key '" + key + "': " + std::string(e.what()) + "\n");
+		}
 	}
 	
 	// ファイルに書き出し
 	std::ofstream ofs(fullPath);
 	if (!ofs)
 	{
-		Logger::Log("Failed to open JSON file for writing: " + path);
+		Logger::Log("[JSON Error] Failed to open JSON file for writing: " + fullPath + "\n");
 		return false;
 	}
 
-	// 整形して出力
-	ofs << json.dump(kJsonIndent);
+	try
+	{
+		// 整形して出力
+		ofs << json.dump(kJsonIndent);
+	}
+	catch (const std::exception& e)
+	{
+		Logger::Log("[JSON Error] Exception during JSON write to file '" + fullPath + "': " + std::string(e.what()) + "\n");
+		return false;
+	}
+
 	return true;
 }
 
 void JsonEditableBase::DrawImGui()
 {
 	ImGui::SeparatorText("Settings");
-	// 登録済みの描画関数を実行
-	for (auto& [name, drawer] : drawers_)
+
+	// フィルターとコントロール行
+	filter_.Draw("Filter", 180.0f);
+	ImGui::SameLine();
+	if (ImGui::Button("Expand All"))
 	{
-		drawer();
+		expandCollapseTrigger_ = 1;
 	}
+	ImGui::SameLine();
+	if (ImGui::Button("Collapse All"))
+	{
+		expandCollapseTrigger_ = 2;
+	}
+
+	bool inTable = false;
+
+	// 登録順に従って描画
+	for (const std::string& name : registrationOrder_)
+	{
+		// フィルターが有効な場合はマッチするかチェック
+		if (!filter_.PassFilter(name.c_str()))
+		{
+			continue;
+		}
+
+		auto itDrawer = drawers_.find(name);
+		if (itDrawer == drawers_.end())
+		{
+			continue;
+		}
+
+		bool isComp = isComposite_.at(name);
+
+		if (isComp)
+		{
+			// テーブルが開いていれば閉じる
+			if (inTable)
+			{
+				ImGui::EndTable();
+				inTable = false;
+			}
+			
+			// 複合型の描画（個別のツリーノードなど）
+			itDrawer->second();
+		}
+		else
+		{
+			// 基本型：テーブル内に配置
+			if (!inTable)
+			{
+				if (ImGui::BeginTable("BasicPropertiesTable", 2, ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_RowBg))
+				{
+					ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 150.0f);
+					ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableHeadersRow();
+					inTable = true;
+				}
+			}
+
+			if (inTable)
+			{
+				itDrawer->second();
+			}
+		}
+	}
+
+	if (inTable)
+	{
+		ImGui::EndTable();
+	}
+
+	// トリガーのリセット
+	expandCollapseTrigger_ = 0;
 }
 
 void JsonEditableBase::DrawOptions()
 {
 	ImGui::SeparatorText("Options");
+
+	// 現在のファイル名の編集用バッファ
+	char fileBuf[256];
+	strncpy_s(fileBuf, fileName.c_str(), sizeof(fileBuf));
+	fileBuf[sizeof(fileBuf) - 1] = '\0';
+	
+	ImGui::PushItemWidth(250.0f);
+	if (ImGui::InputText("Target File Name", fileBuf, sizeof(fileBuf)))
+	{
+		fileName = fileBuf;
+	}
+	ImGui::PopItemWidth();
+
+	// ファイルリストの取得
+	std::vector<std::string> jsonFiles;
+	try
+	{
+		if (std::filesystem::exists(dirPath))
+		{
+			for (const auto& entry : std::filesystem::directory_iterator(dirPath))
+			{
+				if (entry.is_regular_file() && entry.path().extension() == ".json")
+				{
+					jsonFiles.push_back(entry.path().filename().string());
+				}
+			}
+		}
+	}
+	catch (const std::exception& e)
+	{
+		Logger::Log("[JSON Error] Exception scanning directory: " + std::string(e.what()) + "\n");
+	}
+
+	// ドロップダウンでファイル一覧を表示
+	if (!jsonFiles.empty())
+	{
+		ImGui::SameLine();
+		ImGui::PushItemWidth(200.0f);
+		if (ImGui::BeginCombo("##FileSelect", fileName.c_str()))
+		{
+			for (const auto& file : jsonFiles)
+			{
+				bool isSelected = (fileName == file);
+				if (ImGui::Selectable(file.c_str(), isSelected))
+				{
+					fileName = file;
+					LoadJson(fileName); // 選択時に即時ロードする
+				}
+				if (isSelected)
+				{
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+		ImGui::PopItemWidth();
+	}
+
+	ImGui::Spacing();
+
 	// 保存ボタン
 	if (ImGui::Button("Save Json"))
 	{

--- a/project/engine/jsonEditor/JsonEditableBase.h
+++ b/project/engine/jsonEditor/JsonEditableBase.h
@@ -91,6 +91,11 @@ private:
 	std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> setters_;   // 値設定関数マップ
 	std::unordered_map<std::string, std::function<void()>> drawers_;                        // ImGui描画関数マップ
 
+	std::vector<std::string> registrationOrder_;                                             // 登録順序を保持するリスト
+	std::unordered_map<std::string, bool> isComposite_;                                     // 複合型かどうかのフラグマップ
+	ImGuiTextFilter filter_;                                                                // 検索用フィルター
+	int expandCollapseTrigger_ = 0;                                                         // 一括展開/折りたたみ用トリガー（0:なし、1:展開、2:折りたたみ）
+
 	std::vector<std::shared_ptr<void>> registeredMembers_; // 登録されたメンバ変数のポインタを保持
 	const std::string dirPath = "Resources/json/";         // JSONファイルのディレクトリパス
 	std::string fileName;                                   // JSONファイル名
@@ -112,6 +117,20 @@ void JsonEditableBase::Register(const std::string& name, T* value)
 	// 型名を出力
 	Logger::Log("Register: " + name + " type: " + std::string(typeid(T).name()) + "\n");
 
+	// 登録順序を保存
+	registrationOrder_.push_back(name);
+
+	// 複合型（ツリーノードで描画すべきか）判定
+	bool isComp = false;
+	if constexpr (std::is_same_v<T, Transform> ||
+		std::is_same_v<T, std::vector<Transform>> ||
+		std::is_same_v<T, std::vector<Vector3>> ||
+		std::is_same_v<T, std::vector<std::string>>)
+	{
+		isComp = true;
+	}
+	isComposite_[name] = isComp;
+
 	// nlohmann::jsonのto_json/from_jsonに委譲
 	getters_[name] = [value]() {
 		return nlohmann::json(*value);
@@ -126,32 +145,206 @@ void JsonEditableBase::Register(const std::string& name, T* value)
 		};
 
 	// --- ImGui 描画関数登録 ---
-	drawers_[name] = [value, name]() {
-		ImGui::PushID(name.c_str());
-		if (ImGui::CollapsingHeader(name.c_str()))
-		{
-			// 型ごとの描画関数に委譲
+	if constexpr (!std::is_same_v<T, Transform> &&
+		!std::is_same_v<T, std::vector<Transform>> &&
+		!std::is_same_v<T, std::vector<Vector3>> &&
+		!std::is_same_v<T, std::vector<std::string>>)
+	{
+		// 基本データ型：テーブルレイアウト対応の描画処理
+		drawers_[name] = [value, name]() {
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("%s", name.c_str());
+			ImGui::TableSetColumnIndex(1);
+			ImGui::PushItemWidth(-FLT_MIN);
+			ImGui::PushID(name.c_str());
 			if constexpr (std::is_same_v<T, float>)
-				DrawImGuiForFloat(name, value);
+			{
+				ImGui::DragFloat("##value", value, 0.1f);
+			}
 			else if constexpr (std::is_same_v<T, int>)
-				DrawImGuiForInt(name, value);
+			{
+				ImGui::DragInt("##value", value);
+			}
 			else if constexpr (std::is_same_v<T, bool>)
-				DrawImGuiForBool(name, value);
+			{
+				ImGui::Checkbox("##value", value);
+			}
 			else if constexpr (std::is_same_v<T, Vector3>)
-				DrawImGuiForVector3(name, value);
-			else if constexpr (std::is_same_v<T, Transform>)
-				DrawImGuiForTransform(name, value);
-			else if constexpr (std::is_same_v<T, std::vector<Transform>>)
-				DrawImGuiForTransformVector(name, value);
-			else if constexpr (std::is_same_v<T, std::vector<Vector3>>)
-				DrawImGuiForVector3Vector(name, value);
+			{
+				ImGui::DragFloat3("##value", &value->x, 0.1f);
+			}
 			else if constexpr (std::is_same_v<T, std::string>)
-				DrawImGuiForString(name, value);
-			else if constexpr (std::is_same_v<T, std::vector<std::string>>)
-				DrawImGuiForStringVector(name, value);
-			else
-				Logger::Log("Unsupported type for ImGui drawing: " + std::string(typeid(T).name()) + "\n");
-		}
-		ImGui::PopID();
-		};
+			{
+				char buf[256];
+				strncpy_s(buf, value->c_str(), sizeof(buf));
+				buf[sizeof(buf) - 1] = '\0';
+				if (ImGui::InputText("##value", buf, sizeof(buf)))
+				{
+					*value = buf;
+				}
+			}
+			ImGui::PopID();
+			ImGui::PopItemWidth();
+			};
+	}
+	else
+	{
+		// 複合データ型：ツリーノードによる個別階層描画
+		drawers_[name] = [value, name, this]() {
+			ImGui::PushID(name.c_str());
+			if (expandCollapseTrigger_ == 1)
+			{
+				ImGui::SetNextItemOpen(true);
+			}
+			else if (expandCollapseTrigger_ == 2)
+			{
+				ImGui::SetNextItemOpen(false);
+			}
+
+			if (ImGui::TreeNodeEx(name.c_str(), ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				if constexpr (std::is_same_v<T, Transform>)
+				{
+					if (ImGui::BeginTable("TransformTable", 2, ImGuiTableFlags_SizingStretchProp))
+					{
+						ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 100.0f);
+						ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::Text("Translate");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::PushItemWidth(-FLT_MIN);
+						ImGui::DragFloat3("##Translate", &value->translate.x, 0.1f);
+						ImGui::PopItemWidth();
+
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::Text("Rotate");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::PushItemWidth(-FLT_MIN);
+						ImGui::DragFloat3("##Rotate", &value->rotate.x, 0.01f);
+						ImGui::PopItemWidth();
+
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::Text("Scale");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::PushItemWidth(-FLT_MIN);
+						ImGui::DragFloat3("##Scale", &value->scale.x, 0.1f);
+						ImGui::PopItemWidth();
+
+						ImGui::EndTable();
+					}
+				}
+				else if constexpr (std::is_same_v<T, std::vector<Transform>>)
+				{
+					for (size_t i = 0; i < value->size(); ++i)
+					{
+						std::string headerLabel = "Transform[" + std::to_string(i) + "]";
+						ImGui::PushID(static_cast<int>(i));
+						if (expandCollapseTrigger_ == 1) ImGui::SetNextItemOpen(true);
+						else if (expandCollapseTrigger_ == 2) ImGui::SetNextItemOpen(false);
+						if (ImGui::TreeNode(headerLabel.c_str()))
+						{
+							if (ImGui::BeginTable("VectorTransformTable", 2, ImGuiTableFlags_SizingStretchProp))
+							{
+								ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 100.0f);
+								ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+
+								ImGui::TableNextRow();
+								ImGui::TableSetColumnIndex(0);
+								ImGui::Text("Translate");
+								ImGui::TableSetColumnIndex(1);
+								ImGui::PushItemWidth(-FLT_MIN);
+								ImGui::DragFloat3("##Translate", &(*value)[i].translate.x, 0.1f);
+								ImGui::PopItemWidth();
+
+								ImGui::TableNextRow();
+								ImGui::TableSetColumnIndex(0);
+								ImGui::Text("Rotate");
+								ImGui::TableSetColumnIndex(1);
+								ImGui::PushItemWidth(-FLT_MIN);
+								ImGui::DragFloat3("##Rotate", &(*value)[i].rotate.x, 0.01f);
+								ImGui::PopItemWidth();
+
+								ImGui::TableNextRow();
+								ImGui::TableSetColumnIndex(0);
+								ImGui::Text("Scale");
+								ImGui::TableSetColumnIndex(1);
+								ImGui::PushItemWidth(-FLT_MIN);
+								ImGui::DragFloat3("##Scale", &(*value)[i].scale.x, 0.1f);
+								ImGui::PopItemWidth();
+
+								ImGui::EndTable();
+							}
+							ImGui::TreePop();
+						}
+						ImGui::PopID();
+					}
+					ImGui::Spacing();
+					if (ImGui::Button("Add Transform"))
+					{
+						value->push_back(Transform{ {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f} });
+					}
+					ImGui::SameLine();
+					if (ImGui::Button("Remove Last") && !value->empty())
+					{
+						value->pop_back();
+					}
+				}
+				else if constexpr (std::is_same_v<T, std::vector<Vector3>>)
+				{
+					for (size_t i = 0; i < value->size(); ++i)
+					{
+						std::string label = "Element[" + std::to_string(i) + "]";
+						ImGui::PushID(static_cast<int>(i));
+						ImGui::PushItemWidth(-FLT_MIN);
+						ImGui::DragFloat3(label.c_str(), &(*value)[i].x, 0.1f);
+						ImGui::PopItemWidth();
+						ImGui::PopID();
+					}
+					ImGui::Spacing();
+					if (ImGui::Button("Add Vector3"))
+					{
+						value->push_back(Vector3{ 0.0f, 0.0f, 0.0f });
+					}
+					ImGui::SameLine();
+					if (ImGui::Button("Remove Last") && !value->empty())
+					{
+						value->pop_back();
+					}
+				}
+				else if constexpr (std::is_same_v<T, std::vector<std::string>>)
+				{
+					for (size_t i = 0; i < value->size(); ++i)
+					{
+						std::string label = "Element[" + std::to_string(i) + "]";
+						char buf[256];
+						strncpy_s(buf, (*value)[i].c_str(), sizeof(buf));
+						buf[sizeof(buf) - 1] = '\0';
+						ImGui::PushID(static_cast<int>(i));
+						if (ImGui::InputText(label.c_str(), buf, sizeof(buf)))
+						{
+							(*value)[i] = buf;
+						}
+						ImGui::PopID();
+					}
+					ImGui::Spacing();
+					if (ImGui::Button("Add String"))
+					{
+						value->push_back("");
+					}
+					ImGui::SameLine();
+					if (ImGui::Button("Remove Last") && !value->empty())
+					{
+						value->pop_back();
+					}
+				}
+				ImGui::TreePop();
+			}
+			ImGui::PopID();
+			};
+	}
 }

--- a/project/engine/manager/editor/JsonEditorManager.cpp
+++ b/project/engine/manager/editor/JsonEditorManager.cpp
@@ -1,6 +1,9 @@
 #include "JsonEditorManager.h"
 #include "DebugUIManager.h"
 #include "imgui/imgui.h"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
 
 // シングルトンインスタンスの実体
 std::unique_ptr<JsonEditorManager> JsonEditorManager::instance_ = nullptr;
@@ -21,33 +24,139 @@ void JsonEditorManager::Initialize()
 	editors_.clear();
 
 #ifdef USE_IMGUI
-	// JSONエディタをデバッグUIに登録
+	// JSONエディタをデバッグUIに登録（再起動時に消えないように Project エリアに登録する）
 	DebugUIManager::GetInstance()->RegisterDebugUI(this, "JSON Editor", [this]() {
 		// タブバーを開始
 		if (ImGui::BeginTabBar("EditableTabs"))
 		{
-			// 登録されたすべてのエディタをタブとして表示
+			// 1. 汎用JSON編集タブ（常に表示され、任意のファイル名を指定・選択してロード・編集・保存できる）
+			if (ImGui::BeginTabItem("Raw JSON Editor"))
+			{
+				ImGui::Spacing();
+				ImGui::SeparatorText("Raw JSON File Loader / Editor");
+
+				// ターゲットファイル名
+				char rawFileBuf[256];
+				strncpy_s(rawFileBuf, rawJsonFileName_.c_str(), sizeof(rawFileBuf));
+				rawFileBuf[sizeof(rawFileBuf) - 1] = '\0';
+				ImGui::PushItemWidth(250.0f);
+				if (ImGui::InputText("JSON File Name", rawFileBuf, sizeof(rawFileBuf)))
+				{
+					rawJsonFileName_ = rawFileBuf;
+				}
+				ImGui::PopItemWidth();
+
+				// Resources/json/ のファイル一覧を取得
+				std::vector<std::string> jsonFiles;
+				std::string dirPath = "Resources/json/";
+				try
+				{
+					if (std::filesystem::exists(dirPath))
+					{
+						for (const auto& entry : std::filesystem::directory_iterator(dirPath))
+						{
+							if (entry.is_regular_file() && entry.path().extension() == ".json")
+							{
+								jsonFiles.push_back(entry.path().filename().string());
+							}
+						}
+					}
+				}
+				catch (...) {}
+
+				// ドロップダウン表示
+				if (!jsonFiles.empty())
+				{
+					ImGui::SameLine();
+					ImGui::PushItemWidth(200.0f);
+					if (ImGui::BeginCombo("##RawFileSelectCombo", rawJsonFileName_.c_str()))
+					{
+						for (const auto& file : jsonFiles)
+						{
+							bool isSelected = (rawJsonFileName_ == file);
+							if (ImGui::Selectable(file.c_str(), isSelected))
+							{
+								rawJsonFileName_ = file;
+								// 選択されたファイルを自動ロード
+								std::ifstream ifs(dirPath + rawJsonFileName_);
+								if (ifs)
+								{
+									std::stringstream ss;
+									ss << ifs.rdbuf();
+									rawJsonContentStr_ = ss.str();
+								}
+							}
+						}
+						ImGui::EndCombo();
+					}
+					ImGui::PopItemWidth();
+				}
+
+				ImGui::Spacing();
+
+				// 読込・保存ボタン
+				if (ImGui::Button("Load Raw JSON"))
+				{
+					std::ifstream ifs(dirPath + rawJsonFileName_);
+					if (ifs)
+					{
+						std::stringstream ss;
+						ss << ifs.rdbuf();
+						rawJsonContentStr_ = ss.str();
+					}
+					else
+					{
+						Logger::Log("[JSON Error] Failed to open raw JSON file: " + dirPath + rawJsonFileName_ + "\n");
+						rawJsonContentStr_ = "{}";
+					}
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Save Raw JSON"))
+				{
+					std::ofstream ofs(dirPath + rawJsonFileName_);
+					if (ofs)
+					{
+						ofs << rawJsonContentStr_;
+					}
+					else
+					{
+						Logger::Log("[JSON Error] Failed to save raw JSON file: " + dirPath + rawJsonFileName_ + "\n");
+					}
+				}
+
+				ImGui::Spacing();
+				ImGui::Text("File Contents (Raw Text Edit):");
+
+				// 編集バッファの準備
+				static std::vector<char> textBuf;
+				textBuf.assign(rawJsonContentStr_.begin(), rawJsonContentStr_.end());
+				textBuf.push_back('\0');
+				// バッファを余分に確保
+				if (textBuf.size() < 65536)
+				{
+					textBuf.resize(65536, '\0');
+				}
+
+				if (ImGui::InputTextMultiline("##RawTextEditorArea", textBuf.data(), textBuf.size(), ImVec2(-FLT_MIN, 300.0f), ImGuiInputTextFlags_AllowTabInput))
+				{
+					rawJsonContentStr_ = textBuf.data();
+				}
+
+				ImGui::EndTabItem();
+			}
+
+			// 2. 登録されたすべての C++ オブジェクトエディタをタブとして表示
 			for (const auto& [name, editable] : editors_)
 			{
-				// NULLチェック
 				if (!editable) { continue; }
 
-				// タブアイテムを作成
 				if (ImGui::BeginTabItem(name.c_str()))
 				{
-					// タブがアクティブな間は選択状態にしておく
 					selectedItem_ = name;
 
-					// IDを設定して他のエディタと区別する
 					ImGui::PushID(editable.get());
-
-					// オプションを表示
 					editable->DrawOptions();
-
-					// そのオブジェクトの ImGui UI を表示
 					editable->DrawImGui();
-
-					// IDをポップ
 					ImGui::PopID();
 
 					ImGui::EndTabItem();
@@ -55,7 +164,7 @@ void JsonEditorManager::Initialize()
 			}
 			ImGui::EndTabBar();
 		}
-	}, DebugUIArea::Console);
+	}, DebugUIArea::Project);
 #endif
 }
 

--- a/project/engine/manager/editor/JsonEditorManager.h
+++ b/project/engine/manager/editor/JsonEditorManager.h
@@ -54,6 +54,10 @@ private:
 	// 現在選択されているアイテムの名前
 	std::string selectedItem_;
 
+	// 汎用JSON編集用のメンバ
+	std::string rawJsonFileName_ = "new_data.json";
+	std::string rawJsonContentStr_;
+
 private: // シングルトンインスタンス
 	static std::unique_ptr<JsonEditorManager> instance_;
 	JsonEditorManager() = default;       // コンストラクタ

--- a/project/imgui.ini
+++ b/project/imgui.ini
@@ -1,18 +1,18 @@
 [Window][Hierarchy]
-Pos=0,21
+Pos=17,21
 Size=15,32
-Collapsed=0
-DockId=0x00000001,0
-
-[Window][Inspector]
-Pos=25,21
-Size=7,32
 Collapsed=0
 DockId=0x00000004,0
 
+[Window][Inspector]
+Pos=17,21
+Size=15,32
+Collapsed=0
+DockId=0x00000004,1
+
 [Window][Project]
-Pos=17,38
-Size=6,26
+Pos=0,38
+Size=15,26
 Collapsed=0
 DockId=0x00000008,0
 
@@ -85,7 +85,7 @@ DockId=0x0000000B,3
 Pos=9,196
 Size=1586,522
 Collapsed=0
-DockId=0x00000001
+DockId=0x7C6B3D9B
 
 [Window][JSON Editor]
 Pos=297,404
@@ -112,8 +112,8 @@ Collapsed=0
 DockId=0x0000000B,4
 
 [Window][Console]
-Pos=17,38
-Size=6,26
+Pos=0,38
+Size=15,26
 Collapsed=0
 DockId=0x00000008,1
 
@@ -239,8 +239,8 @@ Size=1920,1009
 Collapsed=0
 
 [Window][Scene]
-Pos=17,21
-Size=6,26
+Pos=0,21
+Size=15,26
 Collapsed=0
 DockId=0x00000007,0
 
@@ -2457,16 +2457,14 @@ Size=395,479
 Collapsed=0
 
 [Docking][Data]
-DockNode        ID=0x00000005 Pos=39,208 Size=347,167 Selected=0xC43DBA57
-DockNode        ID=0x00000006 Pos=23,266 Size=353,167 Selected=0xFA55960B
-DockNode        ID=0x00000009 Pos=60,60 Size=243,32 Selected=0xFCBEAB60
-DockNode        ID=0x0000000B Pos=859,255 Size=428,665 Selected=0x5F0366B7
-DockSpace       ID=0x79094160 Pos=0,19 Size=32,19 CentralNode=1
-DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,21 Size=32,32 Split=X
-  DockNode      ID=0x00000001 Parent=0x7C6B3D9B SizeRef=328,1009 Selected=0x29EABFBD
-  DockNode      ID=0x00000002 Parent=0x7C6B3D9B SizeRef=1590,1009 Split=X
-    DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1204,1009 Split=Y
-      DockNode  ID=0x00000007 Parent=0x00000003 SizeRef=1149,595 CentralNode=1 Selected=0xE192E354
-      DockNode  ID=0x00000008 Parent=0x00000003 SizeRef=1149,387 Selected=0xD04A4B96
-    DockNode    ID=0x00000004 Parent=0x00000002 SizeRef=384,1009 Selected=0xE7039252
+DockNode      ID=0x00000005 Pos=39,208 Size=347,167 Selected=0xC43DBA57
+DockNode      ID=0x00000006 Pos=23,266 Size=353,167 Selected=0xFA55960B
+DockNode      ID=0x00000009 Pos=60,60 Size=243,32 Selected=0xFCBEAB60
+DockNode      ID=0x0000000B Pos=859,255 Size=428,665 Selected=0x5F0366B7
+DockSpace     ID=0x79094160 Pos=0,19 Size=32,19 CentralNode=1
+DockSpace     ID=0x7C6B3D9B Window=0xA87D555D Pos=0,21 Size=32,32 Split=X
+  DockNode    ID=0x00000003 Parent=0x7C6B3D9B SizeRef=1187,1009 Split=Y
+    DockNode  ID=0x00000007 Parent=0x00000003 SizeRef=1149,672 CentralNode=1 Selected=0xE192E354
+    DockNode  ID=0x00000008 Parent=0x00000003 SizeRef=1149,314 Selected=0xD04A4B96
+  DockNode    ID=0x00000004 Parent=0x7C6B3D9B SizeRef=731,1009 Selected=0x29EABFBD
 


### PR DESCRIPTION
LoadJson および SaveJson で発生する構文解析エラーや不正な型代入などの例外を try-catch でトラップするようにしました。 読み込み・保存失敗時は Logger::Log を介して、失敗したファイルパスや対象のキー、具体的なエラー原因（[JSON Error] ... / [JSON Warning] ...）を詳細に出力するようにしました。
2. UIレイアウト・視認性の改善 登録順の維持: メンバ変数の登録順序（REGISTER_MEMBER を呼んだ順）を保持し、エディタ上の表示順がランダムにならないようにしました。 グリッド（テーブル）表示: 基本型（float, int, bool, Vector3, string）は個別の折りたたみヘッダーを使わず、「Property」と「Value」の2列のテーブル（表形式） 内にコンパクトに並べて描画するようにしました。 複合型のツリー表示と一括制御: Transform や std::vector などの複合型のみ TreeNodeEx による折りたたみツリーで描画し、上部の「Expand All」「Collapse All」ボタンから一括で開閉できるようにしました。 検索フィルタ: 上部の「Filter」入力欄から、プロパティ名の一部で動的に絞り込み表示を行えるようにしました。
3. エディタ上でのロード・セーブ機能の拡張 各設定項目内に「Target File Name（手動入力欄）」と、Resources/json/ フォルダ内のJSONファイルを自動取得する「ファイル選択ドロップダウン」を追加しました。 ファイルを選択すると即座に自動ロードされ、手動で別名を入力して保存することで簡単に別名保存（エクスポート）ができます。
4. ウィンドウ位置の消失バグ修正 再起動するたびにJSONエディタが消えていたバグを修正しました（初期位置を画面下部に常時表示される Project エリアに変更したため、位置がリセットされなくなりました）。
5. 汎用JSONエディタ（Raw JSON Editor）の追加 設定対象オブジェクトが登録されていない初期状態（タイトル画面など）でも、任意のファイルをロード・直接テキスト編集・保存ができる汎用タブ「Raw JSON Editor」をエディタの先頭に常設しました。